### PR TITLE
Make `sort_at_path` return an empty table instead of failing.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rtables
 Title: Reporting Tables
 Date: 2020-09-25
-Version: 0.3.2.17.9048
+Version: 0.3.2.17.9050
 Authors@R: c(
   person("Adrian", "Waddell", email = "adrian.waddell@roche.com", role = c("aut", "cre")),
   person("Gabriel", "Becker", email = "gabembecker@gmail.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## rtables 0.3.2.17.9050
+
+* `sort_at_path` just returns empty input tables instead of failing
+
 ## rtables 0.3.2.17.9049
 
 * `rbind`/`cbind_rtables` throw errors on non-compatible top-left material

--- a/R/tt_sort.R
+++ b/R/tt_sort.R
@@ -59,6 +59,11 @@ cont_n_onecol <- function(j) {
 #' @export
 sort_at_path <- function(tt, path, scorefun, decreasing = NA, na.pos = c("omit", "last", "first")) {
 
+    # If the table is empty, nothing can be sorted, so just return it directly.  
+    if (is.null(tt)) {
+      return(tt)
+    }
+  
     ## XXX hacky fix this!!!
     if(identical(obj_name(tt), path[1]))
         path <- path[-1]

--- a/tests/testthat/test-sort-prune.R
+++ b/tests/testthat/test-sort-prune.R
@@ -57,5 +57,19 @@ test_that("provided score functions work", {
     expect_identical(scores, setNames(as.numeric(counts), names(counts)))
 })
 
+test_that("sort_at_path just returns an empty input table", {
+    silly_prune_condition <- function(tt) {
+        return(TRUE)
+    }
+    # Note: not sure why there is a warning from below. Probably separate problem.
+    emptytable <- expect_warning(trim_rows(rawtable, silly_prune_condition))
+    result <- sort_at_path(
+        emptytable, 
+        path = c("ARM", "*", "SEX"), 
+        scorefun = cont_n_allcols
+    )
+    expect_identical(emptytable, result)
+})
+
 
 ## todo test sorting proper


### PR DESCRIPTION
Previously `sort_at_path` just failed with an error. I think it makes sense to just return an empty table immediately since nothing can be further sorted in an empty table.

Note: This failing currently blocks our internal development. So we should get this or another solution.