### PR TITLE
Add `.df_col` as rtables argument for `analyze()`.

### DIFF
--- a/R/colby_constructors.R
+++ b/R/colby_constructors.R
@@ -635,7 +635,8 @@ split_rows_by_cutfun = function(lyt, var,
 #'   \item{.N_col}{column-wise N (column count) for the full column being tabulated within}
 #'   \item{.N_total}{overall N (all observation count, defined as sum of column counts) for the tabulation}
 #'   \item{.N_row}{row-wise N (row group count) for the group of observations being analyzed (ie with no column-based subsetting)}
-#'   \item{.df_row}{ data.frame for observations in the row group being analyzed (ie with no column-based subsetting)}
+#'   \item{.df_row}{data.frame for observations in the row group being analyzed (ie with no column-based subsetting)}
+#'   \item{.df_col}{data.frame for observations in the column being analyzed (ie with no row-based subsetting)}
 #'   \item{.var}{variable that is analyzed}
 #'   \item{.ref_group}{data.frame or vector of subset corresponding to the `ref_group` column including subsetting
 #'   defined by row-splitting. Optional and only required/meaningful if a `ref_group` column has been defined}

--- a/R/split_funs.R
+++ b/R/split_funs.R
@@ -115,6 +115,22 @@ setGeneric(".applysplit_ref_vals",
     partinfo
 }
 
+.add_col_extras <- function(spl, df, partinfo) {
+  vnames <- value_names(partinfo$values)
+  if(is.null(partinfo$extras)) {
+    # not sure if this is the right structure or needed:
+    partinfo$extras <- setNames(replicate(length(vnames), list()), vnames)
+  } else {
+    newextras <- mapply(function(old, df)
+      c(old, list(.df_col = df, .n_col = nrow(df))),
+      old = partinfo$extras,
+      df = partinfo$datasplit,
+      SIMPLIFY = FALSE)
+    names(newextras) <- vnames
+    partinfo$extras <- newextras
+  }
+  partinfo
+}
 
 ### NB This is called at EACH level of recursive splitting
 do_split = function(spl, df, vals = NULL, labels = NULL, trim = FALSE) {
@@ -135,6 +151,10 @@ do_split = function(spl, df, vals = NULL, labels = NULL, trim = FALSE) {
     ## this adds .ref_full and .in_ref_col
     if(is(spl, "VarLevWBaselineSplit"))
         ret = .add_ref_extras(spl, df, ret)
+    
+    ## this adds .df_col and .n_col
+    if(is(spl, "VarLevelSplit"))
+      ret = .add_col_extras(spl, df, ret)
 
     ## this:
     ## - guarantees that ret$values contains SplitValue objects

--- a/R/split_funs.R
+++ b/R/split_funs.R
@@ -122,7 +122,7 @@ setGeneric(".applysplit_ref_vals",
     partinfo$extras <- setNames(replicate(length(vnames), list()), vnames)
   } else {
     newextras <- mapply(function(old, df)
-      c(old, list(.df_col = df, .n_col = nrow(df))),
+      c(old, list(.df_col = df)),
       old = partinfo$extras,
       df = partinfo$datasplit,
       SIMPLIFY = FALSE)
@@ -152,7 +152,7 @@ do_split = function(spl, df, vals = NULL, labels = NULL, trim = FALSE) {
     if(is(spl, "VarLevWBaselineSplit"))
         ret = .add_ref_extras(spl, df, ret)
     
-    ## this adds .df_col and .n_col
+    ## this adds .df_col
     if(is(spl, "VarLevelSplit"))
       ret = .add_col_extras(spl, df, ret)
 

--- a/R/tt_dotabulation.R
+++ b/R/tt_dotabulation.R
@@ -1,6 +1,6 @@
 
-match_extra_args = function(f, .N_col, .N_total, .var, .ref_group = NULL, .ref_full = NULL, .in_ref_col = NULL, .parent_splval = NULL, .N_row, .df_row, extras) {
-    possargs = c(list(.N_col = .N_col, .N_total = .N_total, .N_row = .N_row, .df_row = .df_row),
+match_extra_args = function(f, .N_col, .N_total, .var, .ref_group = NULL, .ref_full = NULL, .in_ref_col = NULL, .parent_splval = NULL, .N_row, .df_row, .df_col, extras) {
+    possargs = c(list(.N_col = .N_col, .N_total = .N_total, .N_row = .N_row, .df_row = .df_row, .df_col = .df_col),
                  extras)
     ## specialized arguments that must be named in formals, cannot go anonymously into ...
     if(!is.null(.var) && nzchar(.var))
@@ -52,6 +52,10 @@ gen_onerv = function(csub, col, count, cextr, dfpart, func, totcount, splextra,
         if(!is.null(fullrefcoldat))
             cextr$.in_ref_col = NULL
 
+        dfcol = cextr$.df_col
+        if(!is.null(dfcol))
+            cextr$.df_col = NULL
+        
         exargs = c(cextr, splextra)
 
         ## behavior for x/df and ref-data (full and group)
@@ -74,6 +78,7 @@ gen_onerv = function(csub, col, count, cextr, dfpart, func, totcount, splextra,
                                   .in_ref_col = inrefcol,
                                   .N_row = NROW(dfpart),
                                   .df_row = dfpart,
+                                  .df_col = dfcol,
                                   .parent_splval = last_splval,
                                   extras = c(cextr,
                                              splextra)))

--- a/man/analyze.Rd
+++ b/man/analyze.Rd
@@ -72,7 +72,8 @@ machinery. These are as follows:
 \item{.N_col}{column-wise N (column count) for the full column being tabulated within}
 \item{.N_total}{overall N (all observation count, defined as sum of column counts) for the tabulation}
 \item{.N_row}{row-wise N (row group count) for the group of observations being analyzed (ie with no column-based subsetting)}
-\item{.df_row}{ data.frame for observations in the row group being analyzed (ie with no column-based subsetting)}
+\item{.df_row}{data.frame for observations in the row group being analyzed (ie with no column-based subsetting)}
+\item{.df_col}{data.frame for observations in the column being analyzed (ie with no row-based subsetting)}
 \item{.var}{variable that is analyzed}
 \item{.ref_group}{data.frame or vector of subset corresponding to the \code{ref_group} column including subsetting
 defined by row-splitting. Optional and only required/meaningful if a \code{ref_group} column has been defined}

--- a/tests/testthat/test-lyt-tabulation.R
+++ b/tests/testthat/test-lyt-tabulation.R
@@ -602,6 +602,22 @@ test_that(".df_row analysis function argument works", {
                                ARM2 = c(nfemale, narm2))))
 })
 
+test_that(".df_col works", {
+  afun <- function(df, .N_col, .df_col) {
+    n_col <- nrow(.df_col)
+    rcell(c(n_col, .N_col), format = "xx / xx")
+  }
+  
+  l <- basic_table() %>%
+    split_cols_by("ARM") %>%
+    add_colcounts() %>%
+    # split_cols_by("STRATA1") %>%
+    split_rows_by("RACE", split_fun = drop_split_levels) %>%
+    analyze("AGE", afun = afun) 
+  
+  result <- expect_silent(build_table(l, DM, col_counts = c(200, 300, 400)))
+})
+
 test_that("analyze_colvars inclNAs works", {
 
     ## inclNAs


### PR DESCRIPTION
This addresses a need we identified in https://github.com/Roche/rtables/issues/117.

It would be great if you could have a look at this. One problem is here still that
it only works when there is a single column split. It does not work correctly when there are two or more column splits. Maybe there is a simple way to make it work?...