### PR TITLE
htmltools suggestions

### DIFF
--- a/R/as_html.R
+++ b/R/as_html.R
@@ -55,9 +55,9 @@ insert_brs <- function(vec) {
 as_html <- function(x,
                     width = NULL,
                     class_table = "table table-condensed table-hover",
-                    class_tr = "",
-                    class_td = "",
-                    class_th = "",
+                    class_tr = NULL,
+                    class_td = NULL,
+                    class_th = NULL,
                     caption_txt = NULL,
                     link_label = NULL) {
   
@@ -88,8 +88,12 @@ as_html <- function(x,
       tagfun <- if(inhdr) tags$th else tags$td
       algn <- unique(curaligns)
       stopifnot(length(algn) == 1)
-      args <- list(class = paste(if(inhdr) class_th else class_tr, if(j > 1 || i > nrh) paste0("text-", algn), collapse = " "), colspan = curspn)
-      cells[i, j][[1]] <- do.call(tagfun, c(insert_brs(curstrs), args))
+      cells[i, j][[1]] <- tagfun(
+        class = if (inhdr) class_th else class_tr,
+        class = if(j > 1 || i > nrh) paste0("text-", algn),
+        colspan = curspn,
+        insert_brs(curstrs)
+      )
     }
   }
   
@@ -115,9 +119,12 @@ as_html <- function(x,
   cells[!mat$display] <- NA_integer_
   
   rows <- apply(cells, 1, function(row) {
-    do.call(tags$tr, c(Filter(function(x) !identical(x, NA_integer_), row), list(class = class_tr)))
+    tags$tr(
+      class = class_tr,
+      Filter(function(x) !identical(x, NA_integer_), row)
+    )
   })
-  
+
   if(!is.null(caption_txt)) {
     if(!is.null(link_label))
       labtxt <- sprintf("(#tab:%s)", link_label)
@@ -128,6 +135,5 @@ as_html <- function(x,
   } else {
     captag <- NULL
   }
-  do.call(tags$table, c(rows, list(class = class_table), if(!is.null(captag)) list(captag)))
-  
+  tags$table(class = class_table, rows, captag)
 }

--- a/tests/testthat/test-split_funs.R
+++ b/tests/testthat/test-split_funs.R
@@ -85,7 +85,7 @@ test_that("trim_levels_to_map split function works", {
                                            "HIGH",
                        "IMMUNOLOGY", "IGA", "HIGH"))
 
-    map2 <- tribble(
+    map2 <- tibble::tribble(
         ~ARM, ~RACE,
         "A: Drug X", "ASIAN",
         "A: Drug X", "WHITE",


### PR DESCRIPTION
It shouldn't ever be necessary to call do.call() on htmltools tag
functions, due to several little-known features:

1. `NULL` arguments are ignored
2. Children can be nested in lists, they'll be treated like they
   were passed directly
3. Multiple `class` arguments are automatically pasted together
   with a space in between

Also, it's not relevant for the current `as_html` implementation, but it's possible to use tidyeval semantics as well (e.g. for dynamic attribute names, you can use `div(!!attrib_name := attrib_value)`, or `div(!!!attribs)`).