### PR TITLE
Corrected "devtool" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ or you can install the latest development version directly from GitHub
 with:
 
 ``` r
-devtool::install_github("Roche/rtables")
+remotes::install_github("Roche/rtables")
 ```
 
 Packaged releases (both those on CRAN and those between official CRAN


### PR DESCRIPTION
It should be "devtools", but "remotes" is the primary source anyway