### PR TITLE
Subsetting should lose header and footer if not differently specified…

### DIFF
--- a/R/split_funs.R
+++ b/R/split_funs.R
@@ -1048,7 +1048,6 @@ trim_levels_to_map <- function(map = NULL) {
                                      reorder = TRUE)
         ret <- ksl_fun(df, spl, vals, labels, trim = trim)
 
-  ##      browser()
         if(length(ret$datasplit) == 0) {
             msg <- paste(sprintf("%s[%s]", .spl_context$split, .spl_context$value),
                          collapse = "->")

--- a/R/tt_compare_tables.R
+++ b/R/tt_compare_tables.R
@@ -51,7 +51,11 @@ trim_rows <- function(tt, criteria = all_zero_or_na) {
     rows <- collect_leaves(tt, TRUE, TRUE)
     torm <- vapply(rows, criteria,
                   NA, USE.NAMES = FALSE)
-    tt[!torm, , keep_topleft = TRUE]
+    tt[!torm, , 
+       keep_topleft = TRUE, 
+       keep_titles = TRUE, 
+       keep_footers = TRUE, 
+       reindex_refs = TRUE]
 }
 
 #' @rdname trim_prune_funs

--- a/man/brackets.Rd
+++ b/man/brackets.Rd
@@ -26,7 +26,7 @@
 \alias{[}
 \alias{reexports}
 \alias{[<-}
-\title{retrieve and assign elements of a TableTree}
+\title{Retrieve and assign elements of a \code{TableTree}}
 \usage{
 \S4method{[}{VTableTree,ANY,ANY,list}(x, i, j, ...) <- value
 
@@ -67,51 +67,113 @@ x[i, j, ...] <- value
 
 \item{\dots}{Includes
 \describe{
-\item{\emph{keep_topleft}}{ logical(1) (\code{[} only) Should the 'top-left'
-material for the table be retained after subsetting. Defaults to \code{NA},
-which retains the material if all rows are included (ie subsetting was by
-column), and drops it otherwise.}
-\item{\emph{keep_titles}}{logical(1) Should title and non-referential footer
-information be retained. Defaults to \code{FALSE}}
+\item{\emph{keep_topleft}}{logical(1) (\code{[} only) Should the \code{top-left}
+material for the table be retained after subsetting. Defaults to \code{TRUE} if
+all rows are included (i.e. subsetting was by column), and drops it otherwise.}
+\item{\emph{keep_titles}}{logical(1) Should title information be retained. Defaults to \code{FALSE}.}
+\item{\emph{keep_footers}}{logical(1) Should non-referential footer
+information be retained. Defaults to \code{keep_titles}.}
 \item{\emph{reindex_refs}}{logical(1). Should referential footnotes be
 re-indexed as if the resulting subset is the entire table. Defaults to
-\code{TRUE}}
+\code{TRUE}.}
 }}
 
 \item{value}{Replacement value (list, \code{TableRow}, or \code{TableTree})}
 
-\item{drop}{logical(1). Should the value in the cell be returned if only one
-cell is selected by the combination of \code{i} and \code{j}. Defaults to
-\code{FALSE}}
+\item{drop}{logical(1). Should the value in the cell be returned if one
+cell is selected by the combination of \code{i} and \code{j}. It is not possible
+to return a vector of values. To do so please consider using \code{\link[=cell_values]{cell_values()}}.
+Defaults to \code{FALSE}.}
 }
 \value{
 a \code{TableTree} (or \code{ElementaryTable}) object, unless a
 single cell was selected with \code{drop=TRUE}, in which case the (possibly
 multi-valued) fully stripped raw value of the selected cell.
 }
+\details{
+by default, subsetting drops the information about title, subtitle,
+main footer, provenance footer, and \code{topleft}. If only a column is selected
+and all rows are kept, the \code{topleft} information remains as default. Any
+referential footnote is kept whenever the subset table contains the
+referenced element.
+}
+\note{
+subsetting always preserve the original order, even if provided
+indexes do not preserve it. If sorting is needed, please consider
+using \code{sort_at_path()}. Also note that \code{character} indices are treated as paths,
+not vectors of names in both \code{[} and \verb{[<-}.
+}
 \examples{
-lyt <- basic_table() \%>\%
+lyt <- basic_table(title = "Title", 
+                   subtitles = c("Sub", "titles"), 
+                   prov_footer = "prov footer", 
+                   main_footer = "main footer") \%>\%
    split_cols_by("ARM") \%>\%
-   analyze(c("SEX", "AGE"))
+   split_rows_by("SEX") \%>\%
+   analyze(c("AGE"))
 
 tbl <- build_table(lyt, DM)
+top_left(tbl) <- "Info"
 tbl
 
+# As default header, footer, and topleft information is lost
 tbl[1, ]
 tbl[1:2, 2]
 
+# Also boolean filters can work
+tbl[, c(FALSE, TRUE, FALSE)]
+
+# If drop = TRUE, the content values are directly retrieved
 tbl[2, 1]
 tbl[2, 1, drop = TRUE]
 
+# Drop works also if vectors are selected, but not matrices
+tbl[, 1, drop = TRUE]
+tbl[2, , drop = TRUE]
+tbl[1, 1, drop = TRUE] # NULL because it is a label row
+tbl[2, 1:2, drop = TRUE] # vectors can be returned only with cell_values()
+tbl[1:2, 1:2, drop = TRUE] # no dropping because it is a matrix
+
+# If all rows are selected, topleft is kept by default
+tbl[, 2]
 tbl[, 1]
 
+# It is possible to deselect values
 tbl[-2, ]
 tbl[, -1]
 
+# Values can be reassigned
 tbl[2, 1] <- rcell(999)
 tbl[2, ] <- list(rrow("FFF", 888, 666, 777))
-tbl[3, ] <- list(-111, -222, -333)
+tbl[6, ] <- list(-111, -222, -333)
 tbl
+
+# We can keep some information from the original table if we need
+tbl[1, 2, keep_titles = TRUE]
+tbl[1, 2, keep_footers = TRUE, keep_titles = FALSE]
+tbl[1, 2, keep_footers = FALSE, keep_titles = TRUE]
+tbl[1, 2, keep_footers = TRUE]
+tbl[1, 2, keep_topleft = TRUE]
+
+# Keeps the referential footnotes when subset contains them
+fnotes_at_path(tbl, rowpath = c("SEX", "M", "AGE", "Mean")) <- "important"
+tbl[4, 1]
+tbl[2, 1] # None present
+
+# We can reindex referential footnotes, so that the new table does not depend
+#  on the original one
+fnotes_at_path(tbl, rowpath = c("SEX", "U", "AGE", "Mean")) <- "important"
+tbl[, 1] # both present
+tbl[5:6, 1] # {1} because it has been indexed again
+tbl[5:6, 1, reindex_refs = FALSE] # {2} -> not reindexed
+
+# Note that order can not be changed with subsetting
+tbl[c(4, 3, 1), c(3, 1)] # It preserves order and wanted selection
+
+}
+\seealso{
+Regarding sorting: \code{sort_at_path()} and how to understand path
+structure: \code{summarize_row_groups()}, and \code{summarize_col_groups()}.
 }
 \keyword{internal}
 \description{

--- a/man/head_tail.Rd
+++ b/man/head_tail.Rd
@@ -16,6 +16,7 @@ head(x, ...)
   ...,
   keep_topleft = TRUE,
   keep_titles = TRUE,
+  keep_footers = keep_titles,
   reindex_refs = FALSE
 )
 
@@ -27,6 +28,7 @@ tail(x, ...)
   ...,
   keep_topleft = TRUE,
   keep_titles = TRUE,
+  keep_footers = keep_titles,
   reindex_refs = FALSE
 )
 }
@@ -50,8 +52,11 @@ top_left material for the table will be carried over to the
 subset.}
 
 \item{keep_titles}{logical(1).  If \code{TRUE} (the default),
-all title and footer material for the table will be carried over to the
+all title material for the table will be carried over to the
 subset.}
+
+\item{keep_footers}{logical(1). If \code{TRUE}, all footer material for the table
+will be carried over to the subset. It defaults to \code{keep_titles}.}
 
 \item{reindex_refs}{logical(1). Defaults to \code{FALSE}. If \code{TRUE},
 referential footnotes will be reindexed for the subset.}

--- a/tests/testthat/test-pagination.R
+++ b/tests/testthat/test-pagination.R
@@ -290,7 +290,7 @@ test_that("Pagination works with section dividers", {
     ], ttlst[[1]])
 
     expect_identical(
-        export_as_txt(ttlst[[1]][7:8, ]),
+        export_as_txt(ttlst[[1]][7:8, keep_titles = TRUE]),
         "big title\n\n——————————————\n       all obs\n——————————————\nMean    34.89 \n~~~~~~~~~~~~~~\nM             \n"
     )
 

--- a/tests/testthat/test-printing.R
+++ b/tests/testthat/test-printing.R
@@ -298,16 +298,18 @@ test_that("Inset works for table, ref_footnotes, and main footer", {
 
   # Building the table and trimming NAs
   tt <- build_table(lyt, DM)
-  tt <- trim_rows(tt)
+  tt <- prune_table(tt)
+  # tt <- trim_rows(tt)
 
   # Adding references
   # row_paths(tt)
   # row_paths_summary(tt)
+  # col_paths(tt)
+  # col_paths_summary(tt)
   txt1 <- "Not the best but very long one, probably longer than possible."
   txt2 <- "Why trimming does not take it out?"
   fnotes_at_path(tt, rowpath = c("SEX", "F", "AGE", "Mean")) <- txt1
-  fnotes_at_path(tt, rowpath = c("SEX", "UNDIFFERENTIATED")) <- txt2
-
+  fnotes_at_path(tt, rowpath = c("SEX", "M", "AGE", "Mean"), colpath = c("all obs", "all obs")) <- txt2
   # Test also assign function
   table_inset(tt) <- general_inset
 
@@ -331,7 +333,7 @@ test_that("Inset works for table, ref_footnotes, and main footer", {
 
   expect_false(result[[1]]) # No inset
   expect_true(result[[2]]) # Inset
-  expect_true(all(vec_tt[sep_index + 1] == "   =============================="))
+  expect_true(all(vec_tt[sep_index + 1] == "   ===================="))
 })
 
 test_that("Cell and column label wrapping works in printing", {
@@ -339,7 +341,7 @@ test_that("Cell and column label wrapping works in printing", {
     clw <- c(5, 7, 6, 6) + 12
 
     # Checking in detail if Cell values did wrap correctly
-    result <- toString(matrix_form(tt_for_wrap[10, 1], TRUE), widths = c(10, 8), col_gap = 2)
+    result <- toString(matrix_form(tt_for_wrap[10, 1, keep_footers = TRUE], TRUE), widths = c(10, 8), col_gap = 2)
     splitted_res <- strsplit(result, "\n")[[1]]
 
     # First column (rownames) has widths 10 and there is colgap 2

--- a/tests/testthat/test-subset-access.R
+++ b/tests/testthat/test-subset-access.R
@@ -187,15 +187,30 @@ test_that("Duplicate colvars path correctly", {
                      res)
 })
 
-test_that("top_left retention behavior is correct across all scenarios", {
+test_that("top_left, title, footers retention behaviors are correct across all scenarios", {
+    # topleft
     tlval <- "hi"
-    lyt <- basic_table() %>%
+    
+    # title
+    ti <- "ti"
+    sti <- "sti"
+    
+    # footers
+    mf <- "mf"
+    pf <- "pf"
+    rf <- "rf"
+    
+    lyt <- basic_table(title = ti, subtitles = sti, 
+                       main_footer = mf, prov_footer = pf) %>%
         split_cols_by("ARM") %>%
         append_topleft(tlval) %>%
         split_rows_by("SEX") %>%
         analyze("AGE", mean)
     tbl <- build_table(lyt, DM)
-
+    fnotes_at_path(tbl, rowpath = c("SEX", "F", "AGE", "mean")) <- rf
+    fnotes_at_path(tbl, rowpath = c("SEX", "M", "AGE", "mean")) <- rf
+    
+    # topleft
     expect_identical(top_left(tbl), tlval)
     expect_identical(top_left(tbl[, 1]), tlval) ## default column-only subsetting is TRUE
     expect_identical(top_left(tbl[, 1, keep_topleft = FALSE]), character())
@@ -206,6 +221,49 @@ test_that("top_left retention behavior is correct across all scenarios", {
     expect_identical(top_left(tbl[1:2, 1:2]), character())
     expect_identical(top_left(tbl[1:2, 1:2, keep_topleft = FALSE]), character())
     expect_identical(top_left(tbl[1:2, 1:2, keep_topleft = TRUE]), tlval)
+    
+    # drop = TRUE works
+    expect_identical(suppressWarnings(tbl[1, 1, drop = TRUE]), NULL)
+    expect_warning(tbl[1, 1, drop = TRUE])
+    expect_equal(tbl[2, 1, drop = TRUE], 33.71, tolerance = 0.01)
+
+    # referential footnotes
+    expect_identical(mf_rfnotes(matrix_form(tbl[2, 1])), 
+                     c("F.AGE.mean" = paste0("{1} - ", rf)))
+    expect_identical(mf_rfnotes(matrix_form(tbl[4, 1])), 
+                     c("M.AGE.mean" = paste0("{1} - ", rf)))
+    expect_identical(mf_rfnotes(matrix_form(tbl[4, 1, reindex_refs = FALSE])), 
+                     c("M.AGE.mean" = paste0("{2} - ", rf)))
+    expect_identical(mf_rfnotes(matrix_form(tbl[1, 1])), character())
+    
+    # titles and footers
+    expect_identical(main_title(tbl[1, 1]), "")
+    expect_identical(main_title(tbl[1, 1, keep_titles = FALSE]), "")
+    expect_identical(main_footer(tbl[1, 1, keep_titles = FALSE]), character())
+    expect_identical(main_title(tbl[1, 1, keep_titles = TRUE]), ti)
+    expect_identical(subtitles(tbl[1, 1, keep_titles = TRUE]), sti)
+    expect_identical(main_footer(tbl[1, 1, keep_footers = TRUE]), mf)
+    expect_identical(prov_footer(tbl[1, 1, keep_footers = TRUE]), pf)
+    
+    # Further testing drop = TRUE
+    tbl1 <- basic_table() %>%
+        split_cols_by("ARM") %>%
+        split_rows_by("SEX") %>%
+        analyze("AGE", function(x) list("m (sd)" = c(mean(x), sd(x)))) %>% 
+        build_table(DM)
+    tbl2 <- basic_table() %>%
+        split_cols_by("ARM") %>%
+        split_rows_by("SEX", child_labels = "hidden") %>%
+        analyze("AGE", mean) %>% 
+        build_table(DM)
+    # row with only numbers -> warning
+    expect_warning(tbl[4, , drop = TRUE])
+    # warnings for label row
+    expect_warning(tbl[, 1, drop = TRUE])
+    expect_warning(tbl[3, , drop = TRUE])
+    # warnings for more than one values
+    expect_warning(tbl1[4, , drop = TRUE])
+    expect_warning(tbl1[2, 1:2, drop = TRUE])
 })
 
 test_that("setters work ok", {

--- a/vignettes/subsetting_tables.Rmd
+++ b/vignettes/subsetting_tables.Rmd
@@ -56,12 +56,10 @@ The `[` and `[<-` accessor functions operate largely the same as their `data.fra
    - negative numeric positions are supported, though like `[.data.frame` they cannot be mixed with positive ones
  - `[` always returns the same class as the object being subset unless `drop = TRUE`
  - `[ , drop = TRUE` returns the raw (possibly multi-element) value associated with the cell.
- 
 
 **Known Differences from `[.data.frame`**
-
-- absolute position cannot currently be used to reorder columns or rows
-  - Note in general the result of such an ordering is unlikely to be structurally valid
+- absolute position cannot currently be used to reorder columns or rows. Note in general the result of such an ordering is unlikely to be structurally valid. To change the order of 
+values, please read [sorting and pruning](https://roche.github.io/rtables/main/articles/sorting_pruning.html) vignette or relevant function (`sort_at_path()`).
 - `character` indices are treated as paths, not vectors of names in both `[` and `[<-`
 
 The `[` accessor function always returns an `TableTree` object if `drop=TRUE` is not set. The first argument are the row indices and the second argument the column indices. Alternatively logical subsetting can be used. The indices are based on visible rows and not on the tree structure. So:
@@ -104,7 +102,66 @@ Character indices are interpreted as paths (see below), NOT elements to be match
 tbl[,c("ARM", "A: Drug X")]
 ```
 
+### Dealing with titles, foot notes, and top left information
+As standard no additional information is kept after subsetting. Here, we show with a more
+complete table how it is still possible to keep the (possibly) relevant information.
 
+```{r}
+top_left(tbl) <- "SEX"
+main_title(tbl) <- "Table 1"
+subtitles(tbl) <- c("Authors:", " - Abcd Zabcd", " - Cde Zbcd")
+
+main_footer(tbl) <- "Please regard this table as an example of smart subsetting"
+prov_footer(tbl) <- "Do remember where you read this though"
+
+fnotes_at_path(tbl, rowpath = c("M", "AGE", "Mean"), 
+               colpath = c("ARM", "A: Drug X")) <- "Very important mean"
+```
+
+Normal subsetting loses all the information showed above.
+```{r}
+tbl[3, 3]
+```
+
+If all the rows are kept, top left information is also kept. This can be also
+imposed by adding `keep_topleft = TRUE` to the subsetting as follows:
+
+```{r}
+tbl[, 2:3]
+tbl[1:3, 3, keep_topleft = TRUE]
+```
+
+If the referenced entry is present in the subsetting, also the referential footnote
+will appear. Please consider reading relevant vignette about [referential footnotes](https://roche.github.io/rtables/main/articles/title_footer.html#referential-footnotes). In case of subsetting, the referential footnotes are by default indexed again, 
+as if the produced table is a new one.
+
+
+```{r}
+tbl[10, 1]
+col_paths_summary(tbl) # Use these to find the right path to value or label
+row_paths_summary(tbl) #
+
+# To select column value, use `NULL` for `rowpath`
+fnotes_at_path(tbl, rowpath = NULL, colpath = c("ARM", "A: Drug X")) <- "Interesting"
+tbl[3, 1]
+
+# reindexing of {2} as {1}
+fnotes_at_path(tbl, rowpath = c("M", "AGE", "Mean"), 
+               colpath = NULL) <- "THIS mean"
+tbl # {1}, {2}, and {3} are present
+tbl[10, 2] # only {1} which was previously {2}
+```
+
+Similarly to what we have used to keep top left information, we can specify to 
+keep more information from the original table. As a standard the foot notes are 
+always present if the titles are kept. 
+```{r}
+tbl[1:3, 2:3, keep_titles = TRUE]
+tbl[1:3, 2:3, keep_titles = FALSE, keep_footers = TRUE]
+
+# Referential footnotes are not influenced by `keep_footers = FALSE`
+tbl[1:3, keep_titles = TRUE, keep_footers = FALSE]
+```
 
 ## Path Based Cell Value Accessing:
 Tables can be subset or modified in a structurally aware manner via *pathing*. 


### PR DESCRIPTION
… (#473)

* subsetting works now

* fix?

* reincluded functionality (topleft is true when only col subsetting)

* tests and examples

* fixing standards

* fixes

* adding and fixing documentation

* adding to vignette

* fixing standard in docs

* fixing trim_rows()

* modifications following comments

* update

* fix example

* forgot documenting

* fixing drop behavior

* add tests for new behavior

* fix test

* fixing for label rows and multiple values

* documenting

* removing browser()

* fixing overlapping functions (.h_t_body and .copy_...)

* updating roxygen nte

* why was this different?

* final fix

* fixing docs and tests