### PR TITLE
Allow 2d count (%) formats in column counts

### DIFF
--- a/R/tt_toString.R
+++ b/R/tt_toString.R
@@ -539,6 +539,17 @@ get_formatted_fnotes <- function(tt) {
     if (disp_ccounts(cinfo)) {
         counts <- col_counts(cinfo)
         cformat <- colcount_format(cinfo)
+
+        # allow 2d column count formats (count (%) only)
+        cfmt_dim <- names(which(sapply(formatters::list_valid_format_labels(), function(x) any(x == cformat))))
+        if (cfmt_dim == "2d") {
+            if (grepl("%", cformat)) {
+                counts <- lapply(counts, function(x) c(x, 1))
+            } else {
+                stop("This 2d format is not supported for column counts. Please choose a 1d format or a 2d format that includes a % value.")
+            }
+        } else if (cfmt_dim == "3d") {stop("3d formats are not supported for column counts.")}
+        
         body <- rbind(body, vapply(counts, format_rcell,
                                    character(1),
                                    format = cformat,

--- a/tests/testthat/test-deprecated.R
+++ b/tests/testthat/test-deprecated.R
@@ -87,3 +87,26 @@ test_that("add_colcounts works", {
     
     expect_true(identical(tbl1, tbl2))
 })
+
+test_that("add_colcounts format argument works", {
+    # 2d count (%) format works
+    tbl1 <- basic_table() %>%
+        add_colcounts(format = "xx (xx%)") %>%
+        split_cols_by("ARM") %>%
+        build_table(DM)
+    mf_tbl1_colcounts <- matrix_form(tbl1)$strings[2,]
+    expect_identical(mf_tbl1_colcounts, c("", "121 (100%)", "106 (100%)", "129 (100%)"))
+    
+    # correct error message for 2d format without %
+    lyt <- basic_table() %>%
+        add_colcounts(format = "xx (xx)") %>%
+        split_cols_by("ARM")
+    expect_error(matrix_form(build_table(lyt, DM)),
+                 "This 2d format is not supported for column counts. Please choose a 1d format or a 2d format that includes a % value.")
+    
+    # correct error message for 3d colcount format
+    lyt <- basic_table() %>%
+        add_colcounts(format = "xx.x (xx.x - xx.x)") %>%
+        split_cols_by("ARM")
+    expect_error(matrix_form(build_table(lyt, DM)), "3d formats are not supported for column counts.")
+})


### PR DESCRIPTION
Closes #516 

@gmbecker should I also add the requested `"N=xx (xx%)"` format as a valid 2d format in `formatters`?